### PR TITLE
Проброс makeInstance в JsonStruct и JsonArray

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,7 +1,8 @@
 export type TSerializeFunc<T> = (value: T, instance: any, config: TSerializeConfig) => any;
 export type TSerializeConfig = { allowNullValues?: boolean; autoCreateModelForRawData?: boolean; };
 
-export type TDeserializeFunc<T> = (rawValue: any, rawData?: any) => T;
+export type TDeserializeConfig = {  makeInstance: boolean; };
+export type TDeserializeFunc<T> = (rawValue: any, rawData: any, config: TDeserializeConfig) => T;
 
 export interface PropertyMetadata {
     /**

--- a/src/decorators/JsonArray.ts
+++ b/src/decorators/JsonArray.ts
@@ -1,7 +1,7 @@
 import { JsonName } from './JsonName';
 import { serialize } from './../serialize';
 import { deserialize } from './../deserialize';
-import { TSerializeConfig } from 'core/types';
+import { TDeserializeFunc, TSerializeConfig } from 'core/types';
 
 /**
  * Декоратор для сериализации-десериализации массивов экземпляров.
@@ -31,12 +31,12 @@ export function JsonArray(proto: any, name?: string): (target: object, propertyK
         ).filter(i => !!i);
     };
 
-    const deserializer = (value): any => {
+    const deserializer: TDeserializeFunc<any> = (value, _, config): any => {
         if (!value || !(value instanceof Array)) {
             return null;
         }
         return value.map(
-            item => proto.fromServer ? proto.fromServer(item) : deserialize(item, proto)
+            item => proto.fromServer ? proto.fromServer(item) : deserialize(item, proto, config)
         );
     };
 

--- a/src/decorators/JsonStruct.ts
+++ b/src/decorators/JsonStruct.ts
@@ -19,7 +19,7 @@ export function JsonStruct(TargetClass: any, rawName?: string): (target: object,
         const deserializeFunc = proto.fromServer
             // tslint:disable-next-line
             ? function (value) { return proto.fromServer(value); }
-            : (value): any => value !== null ? deserialize(value, proto) : null;
+            : (value, _, config): any => value !== null ? deserialize(value, proto, config) : null;
 
         const serializerFunc = (value: any, _: any, config?: TSerializeConfig) => {
             if (!value) {

--- a/src/deserialize/deserialize.ts
+++ b/src/deserialize/deserialize.ts
@@ -1,8 +1,5 @@
+import { TDeserializeConfig } from 'core/types';
 import { ClassMetaStore, ParentKey, RootMetaStore } from './../core';
-
-export interface DeserializeConfig {
-    makeInstance: boolean;
-}
 
 /**
  * Хэлпер для десериализации сырых данных в экземпляр данного класса
@@ -10,7 +7,7 @@ export interface DeserializeConfig {
  * @param {{new(...args: any[]): T}} cls - конструктор класса, в экземпляр которого надо превратить данные
  * @returns {T} - экземпляр
  */
-export function deserialize<T>(data: any, cls: { new (...args: Array<any>): T }, config: DeserializeConfig = { makeInstance: true }): T {
+export function deserialize<T>(data: any, cls: { new (...args: Array<any>): T }, config: TDeserializeConfig = { makeInstance: true }): T {
     const { makeInstance } = config;
     const retVal = makeInstance ? new cls() : {};
     const targetClass = cls.prototype;
@@ -37,7 +34,7 @@ export function deserialize<T>(data: any, cls: { new (...args: Array<any>): T },
             const jsonName = serializeProps.rawKey;
             const jsonValue = jsonName !== ParentKey ? data[jsonName] : data;
             if (typeof jsonValue !== 'undefined') {
-                retVal[serializeProps.propertyKey] = deserialize ? deserialize(jsonValue, data) : jsonValue;
+                retVal[serializeProps.propertyKey] = deserialize ? deserialize(jsonValue, data, config) : jsonValue;
             }
         }
     }
@@ -50,7 +47,7 @@ export function deserialize<T>(data: any, cls: { new (...args: Array<any>): T },
             const jsonName = serializeProps.rawKey;
             const jsonValue = jsonName !== ParentKey ? data[jsonName] : data;
             if (typeof jsonValue !== 'undefined') {
-                retVal[serializeProps.propertyKey] = deserialize ? deserialize(jsonValue, retVal) : jsonValue;
+                retVal[serializeProps.propertyKey] = deserialize ? deserialize(jsonValue, retVal, config) : jsonValue;
             }
         }
     }

--- a/src/deserialize/index.ts
+++ b/src/deserialize/index.ts
@@ -1,1 +1,1 @@
-export { DeserializeConfig, deserialize } from './deserialize';
+export { deserialize } from './deserialize';

--- a/test/JsonArray/not-make-instance.ts
+++ b/test/JsonArray/not-make-instance.ts
@@ -1,0 +1,40 @@
+import {deserialize, JsonArray, JsonName, } from './../../src';
+
+class NestedClass2 {
+    @JsonName('nestedField')
+    nestedField: string;
+}
+
+class NestedClass {
+    @JsonArray(NestedClass2, 'array')
+    array: NestedClass2[];
+}
+
+class DeserializerWithoutInstance {
+    @JsonArray(NestedClass, 'nestedArray')
+    nestedArray: NestedClass[];
+}
+
+describe('Deserialize config case', () => {
+    const referenceValue = 'hello';
+    const data = { nestedArray: [{ nestedField: referenceValue, array: [{ nestedField: referenceValue }] }] };
+    const classInstance = deserialize(data, DeserializerWithoutInstance);
+    const objectInstance = deserialize(data, DeserializerWithoutInstance, { makeInstance: false });
+
+    test('class instance instanceof class', () => {
+      expect(classInstance instanceof DeserializerWithoutInstance).toBeTruthy();
+      expect(classInstance.nestedArray[0] instanceof NestedClass).toBeTruthy();
+    });
+
+    test('object instance instanceof object', () => {
+      expect(objectInstance instanceof Object).toBeTruthy();
+    });
+
+    test('object instance in arrays', () => {
+      expect(objectInstance.nestedArray[0] instanceof NestedClass).toBeFalsy();
+    })
+
+    test('object instance in nested arrays', () => {
+      expect(objectInstance.nestedArray[0].array[0] instanceof NestedClass2).toBeFalsy();
+    })
+});

--- a/test/JsonName/not-make-instance.ts
+++ b/test/JsonName/not-make-instance.ts
@@ -1,13 +1,32 @@
-import {deserialize, JsonName, serialize} from './../../src';
+import {deserialize, JsonArray, JsonName, JsonStruct, serialize} from './../../src';
+
+class NestedClass2 {
+    @JsonName('nestedField')
+    nestedField: string;
+}
+
+class NestedClass {
+    @JsonName('nestedField')
+    nestedField: string;
+
+    @JsonArray(NestedClass2, 'array')
+    array: NestedClass2[];
+}
 
 class DeserializerWithoutInstance {
     @JsonName('f')
     fieldToSerialize: string;
+
+    @JsonStruct(NestedClass, 'nested')
+    nested: NestedClass;
+
+    @JsonArray(NestedClass, 'nestedArray')
+    nestedArray: NestedClass[];
 }
 
 describe('Deserialize config case', () => {
     const referenceValue = 'hello';
-    const data = { f: referenceValue };
+    const data = { f: referenceValue, nested: { nestedField: referenceValue }, nestedArray: [{ nestedField: referenceValue, array: [{ nestedField: referenceValue }] }] };
     const defaultInstance = deserialize(data, DeserializerWithoutInstance);
     const objectInstance = deserialize(data, DeserializerWithoutInstance, { makeInstance: false });
 
@@ -16,6 +35,6 @@ describe('Deserialize config case', () => {
     });
 
     test('object instance instanceof object', () => {
-        expect(objectInstance instanceof Object).toBeTruthy();
+      expect(objectInstance instanceof Object).toBeTruthy();
     });
 });

--- a/test/JsonStruct/not-make-instance.ts
+++ b/test/JsonStruct/not-make-instance.ts
@@ -1,0 +1,31 @@
+import {deserialize, JsonName, JsonStruct} from './../../src';
+
+class NestedClass {
+    @JsonName('nestedField')
+    nestedField: string;
+}
+
+class DeserializerWithoutInstance {
+    @JsonStruct(NestedClass, 'nested')
+    nested: NestedClass;
+}
+
+describe('Deserialize config case', () => {
+    const referenceValue = 'hello';
+    const data = { nested: { nestedField: referenceValue } };
+    const classInstance = deserialize(data, DeserializerWithoutInstance);
+    const objectInstance = deserialize(data, DeserializerWithoutInstance, { makeInstance: false });
+
+    test('class instance instanceof class', () => {
+      expect(classInstance instanceof DeserializerWithoutInstance).toBeTruthy();
+      expect(classInstance.nested instanceof NestedClass).toBeTruthy();
+    });
+
+    test('object instance instanceof object', () => {
+      expect(objectInstance instanceof Object).toBeTruthy();
+    });
+      
+    test('object instance for nested model', () => {
+      expect(objectInstance.nested instanceof NestedClass).toBeFalsy();
+    })
+});


### PR DESCRIPTION
**Зачем?**
Чтобы не прописывать во вложенных моделях fromServer c deserialize({ makeInstance: false }) 